### PR TITLE
[Yash]: fix FixedLocator 28 52 bug in evaluate.py

### DIFF
--- a/projects/urban_classifier/configs/cfg.yaml
+++ b/projects/urban_classifier/configs/cfg.yaml
@@ -12,7 +12,7 @@ num_workers: 6
 
 # change data_root to fit my own user directory
 # /home/ykarandikar/crop-test-pipeline -> both folders, crops and split_random, are in here
-data_root: '/home/ykarandikar/crop-test-pipeline'
+data_root: '/home/compbio/GDrive/croppedOutput'
 
 #num_classes: 5
 # 49 classes + 3 (empty, human, vehicle)


### PR DESCRIPTION
Follow Max's suggestion of using predicted_labels to create mapping_inv and legend for matplotlib in order to bugfix FixedLocator issue; also change filepath in cfg.yaml

This commit is based on today's meeting - Max recommended I use predicted_labels as a ground truth and to make both mapping_inv and legend based on predicted_labels count (28 - number of labels instead of 52 - number of classes). This fixed the FixedLocator issue.

Ready to be merged into main branch